### PR TITLE
feat: add snapshot feature

### DIFF
--- a/projects/core/src/providers.ts
+++ b/projects/core/src/providers.ts
@@ -1,4 +1,4 @@
-import {ErrorHandler, inject, Injectable, InjectionToken} from "@angular/core";
+import {ErrorHandler, EventEmitter, inject, Injectable, InjectionToken} from "@angular/core";
 import {Observable, OperatorFunction, Subject, Subscription, switchAll} from "rxjs";
 import {ActionMetadata, EventType, StoreConfig, StoreEvent} from "./interfaces";
 import {track} from "./proxy";
@@ -16,7 +16,7 @@ export const ROOT_CONFIG = new InjectionToken<StoreConfig>("ROOT_CONFIG", {
 })
 export const EVENTS = new InjectionToken("EVENTS", {
    factory() {
-      return new Subject<StoreEvent>()
+      return new EventEmitter<StoreEvent>(true)
    }
 })
 

--- a/projects/core/src/public-api.ts
+++ b/projects/core/src/public-api.ts
@@ -20,4 +20,4 @@ export {Transition, noopTransition} from "./transition"
 export {EVENTS, ACTION} from "./providers";
 export {configureStore, events} from "./utils";
 export {Store, Status, Caught, Select, Layout, Before, Invoke, Action} from "./decorators";
-export { select, selectStore, Selector } from "./select"
+export { select, selectStore, Selector, snapshot } from "./select"

--- a/projects/core/src/public-api.ts
+++ b/projects/core/src/public-api.ts
@@ -12,7 +12,7 @@ export {
    untrack as $$,
 } from "./proxy"
 export {dispatch} from "./dispatch";
-export {useOperator, useConcat, useExhaust, useMerge, useSwitch, addTeardown, useChanges} from "./hooks"
+export {useOperator, useConcat, useExhaust, useMerge, useSwitch, addTeardown, useChanges, action, snapshot} from "./hooks"
 export {attach} from "./attach"
 export {TemplateProvider} from "./template-provider"
 export {loadEffect} from "./load-effect"
@@ -20,4 +20,4 @@ export {Transition, noopTransition} from "./transition"
 export {EVENTS, ACTION} from "./providers";
 export {configureStore, events} from "./utils";
 export {Store, Status, Caught, Select, Layout, Before, Invoke, Action} from "./decorators";
-export { select, selectStore, Selector, snapshot } from "./select"
+export { select, selectStore, Selector } from "./select"

--- a/projects/core/src/utils.ts
+++ b/projects/core/src/utils.ts
@@ -18,12 +18,14 @@ export function wrap(target: { [key: PropertyKey]: any }, property: PropertyKey,
    const object = descriptor ? descriptor : target
    const getOrValue = descriptor?.get ? "get" : "value"
    const originalFunction = (descriptor ? descriptor[getOrValue] : object[property]) ?? noop
+   function wrapped(this: unknown, ...args: any[]) {
+      return fn.call(untrack(this), originalFunction, ...args)
+   }
 
+   Object.defineProperty(wrapped, "name", { value: property })
    Object.defineProperty(target, property, {
       configurable: true,
-      [getOrValue]: function (this: unknown, ...args: any[]) {
-         return fn.call(untrack(this), originalFunction, ...args)
-      }
+      [getOrValue]: wrapped
    })
 
    return originalFunction === noop

--- a/projects/integration/src/app/ui-todos.component.ts
+++ b/projects/integration/src/app/ui-todos.component.ts
@@ -9,7 +9,7 @@ import {
    Status,
    Store, Transition, useMerge,
    events,
-   useChanges
+   useChanges, snapshot
 } from '@antischematic/angular-state-library';
 import {UITodo} from './ui-todo.component';
 import {Observable} from 'rxjs';
@@ -44,7 +44,9 @@ export class UITodos {
 
    uiTodos!: QueryList<UITodos>;
 
-   todos: Todo[] = [];
+   @Select() get todos(): Todo[] {
+      return snapshot(this.loadTodos) ?? []
+   }
 
    @Select() get remaining() {
       // Use "$" to track nested objects or array mutations
@@ -57,9 +59,7 @@ export class UITodos {
 
    @Invoke() loadTodos() {
       // Invoke, Before and Layout react to changes on "this"
-      return dispatch(loadTodos(this.userId), (todos) => {
-         this.todos = todos;
-      });
+      return dispatch(loadTodos(this.userId));
    }
 
    @Layout() countElements() {

--- a/projects/integration/src/app/ui-todos.component.ts
+++ b/projects/integration/src/app/ui-todos.component.ts
@@ -1,15 +1,20 @@
 import {
    $,
    Action,
+   action,
    Caught,
    dispatch,
-   Invoke,
-   Layout, loadEffect,
-   Select,
-   Status,
-   Store, Transition, useMerge,
    events,
-   useChanges, snapshot
+   Invoke,
+   Layout,
+   loadEffect,
+   Select,
+   snapshot,
+   Status,
+   Store,
+   Transition,
+   useChanges,
+   useMerge
 } from '@antischematic/angular-state-library';
 import {UITodo} from './ui-todo.component';
 import {Observable} from 'rxjs';
@@ -45,7 +50,7 @@ export class UITodos {
    uiTodos!: QueryList<UITodos>;
 
    @Select() get todos(): Todo[] {
-      return snapshot(this.loadTodos) ?? []
+      return snapshot(action(this.loadTodos)) ?? []
    }
 
    @Select() get remaining() {
@@ -63,7 +68,7 @@ export class UITodos {
    }
 
    @Layout() countElements() {
-      const { length } = $(this.uiTodos);
+      const {length} = $(this.uiTodos);
       console.log(
          `There ${length === 1 ? 'is' : 'are'} now ${length} <ui-todo> element${
             length === 1 ? '' : 's'
@@ -94,7 +99,7 @@ export class UITodos {
    }
 
    @Invoke() trackInputChanges() {
-      const { userId } = useChanges<UITodos>()
+      const {userId} = useChanges<UITodos>()
       console.log("inputs changed!", userId)
    }
 
@@ -127,7 +132,7 @@ export class UITodos {
 function loadTodos(userId: string): Observable<Todo[]> {
    return inject(HttpClient).get<Todo[]>(
       `https://jsonplaceholder.typicode.com/todos`,
-      { params: { userId } }
+      {params: {userId}}
    );
 }
 
@@ -135,7 +140,7 @@ function createTodo(userId: string, title: string): Observable<Todo> {
    useMerge()
    return inject(HttpClient).post<Todo>(
       'https://jsonplaceholder.typicode.com/todos',
-      { userId, title }
+      {userId, title}
    )
 }
 


### PR DESCRIPTION
Adds a method for selectors to be computed from the output of an observable or action. The subscription is deferred until the value is first read. The selector value is updated each time the observable emits, until it errors or completes. The selector function is called each time reactive dependencies change. When this happens, the previous subscription is replaced with a subscription to the next observable it is given.

```ts
@Store()
@Component()
export class UITodos {
   @Input() userId!: string

   @Select() get remaining() {
      return this.todos.filter(todo => !todo.completed!)
   }

   @Select() get todos() {
      return snapshot(this.loadTodos) ?? []
      // return snapshot(loadTodos(this.userId))
      // return snapshot(resolve(this.loadTodos))
   }

   @Invoke() loadTodos() {
      dispatch(loadTodos(this.userId))
   }
}

function loadTodos(userId: string) {
   return inject(HttpClient).get(endpoint, { 
      params: { userId }
   })
}
```